### PR TITLE
Migrate to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: Version of the Pulumi CLI to install
     default: latest
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.